### PR TITLE
OAuth2

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,5 +1,10 @@
 default:
     suites:
+        user:
+            contexts:
+                - DomainContext
+            filters:
+                role: user
         api:
             contexts:
                 - DomainContext

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "gitory/pimple-cli": "~1.0",
         "symfony/config": "~2.5",
         "monolog/monolog": "~1.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "texthtml/oauth2-provider": "~1.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,102 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "52e14bbf91466bd6b744be8caab6071f",
+    "hash": "353f9b0325df19efbe9fdffec5a44191",
     "packages": [
+        {
+            "name": "bshaffer/oauth2-server-httpfoundation-bridge",
+            "version": "v1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bshaffer/oauth2-server-httpfoundation-bridge.git",
+                "reference": "d9c4b6e30443a688df810db641d8433150bf71af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-httpfoundation-bridge/zipball/d9c4b6e30443a688df810db641d8433150bf71af",
+                "reference": "d9c4b6e30443a688df810db641d8433150bf71af",
+                "shasum": ""
+            },
+            "require": {
+                "bshaffer/oauth2-server-php": ">=0.9",
+                "php": ">=5.3.0",
+                "symfony/http-foundation": ">=2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "OAuth2\\HttpFoundationBridge": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Shaffer",
+                    "email": "bshafs@gmail.com",
+                    "homepage": "http://brentertainment.com"
+                }
+            ],
+            "description": "A bridge to HttpFoundation for oauth2-server-php",
+            "homepage": "http://github.com/bshaffer/oauth2-server-httpfoundation-bridge",
+            "keywords": [
+                "auth",
+                "httpfoundation",
+                "oauth",
+                "oauth2"
+            ],
+            "time": "2014-08-27 15:40:29"
+        },
+        {
+            "name": "bshaffer/oauth2-server-php",
+            "version": "v1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bshaffer/oauth2-server-php.git",
+                "reference": "74fcc75e47614c1417c750e907a44567d9ceee1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/74fcc75e47614c1417c750e907a44567d9ceee1f",
+                "reference": "74fcc75e47614c1417c750e907a44567d9ceee1f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Required to use the DynamoDB storage engine",
+                "predis/predis": "Required to use the Redis storage engine",
+                "thobbs/phpcassa": "Required to use the Cassandra storage engine"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "OAuth2": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Shaffer",
+                    "email": "bshafs@gmail.com",
+                    "homepage": "http://brentertainment.com"
+                }
+            ],
+            "description": "OAuth2 Server for PHP",
+            "homepage": "http://github.com/bshaffer/oauth2-server-php",
+            "keywords": [
+                "auth",
+                "oauth",
+                "oauth2"
+            ],
+            "time": "2014-08-28 02:13:42"
+        },
         {
             "name": "cypresslab/gitelephant",
             "version": "v1.0.10",
@@ -1644,6 +1738,127 @@
                 "url"
             ],
             "time": "2014-09-22 15:28:36"
+        },
+        {
+            "name": "symfony/security",
+            "version": "v2.5.6",
+            "target-dir": "Symfony/Component/Security",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Security.git",
+                "reference": "533f832af99e32dd74d7e3a7d6a3857c3d149614"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Security/zipball/533f832af99e32dd74d7e3a7d6a3857c3d149614",
+                "reference": "533f832af99e32dd74d7e3a7d6a3857c3d149614",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/http-foundation": "~2.1",
+                "symfony/http-kernel": "~2.4"
+            },
+            "replace": {
+                "symfony/security-acl": "self.version",
+                "symfony/security-core": "self.version",
+                "symfony/security-csrf": "self.version",
+                "symfony/security-http": "self.version"
+            },
+            "require-dev": {
+                "doctrine/common": "~2.2",
+                "doctrine/dbal": "~2.2",
+                "ircmaxell/password-compat": "1.0.*",
+                "psr/log": "~1.0",
+                "symfony/expression-language": "~2.4",
+                "symfony/routing": "~2.2",
+                "symfony/validator": "~2.2,<2.5.0"
+            },
+            "suggest": {
+                "doctrine/dbal": "For using the built-in ACL implementation",
+                "ircmaxell/password-compat": "For using the BCrypt password encoder in PHP <5.5",
+                "symfony/class-loader": "For using the ACL generateSql script",
+                "symfony/expression-language": "For using the expression voter",
+                "symfony/finder": "For using the ACL generateSql script",
+                "symfony/routing": "For using the HttpUtils class to create sub-requests, redirect the user, and match URLs",
+                "symfony/validator": "For using the user password constraint"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Security\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Security Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-10-24 05:49:22"
+        },
+        {
+            "name": "texthtml/oauth2-provider",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/texthtml/oauth2-provider.git",
+                "reference": "8c4307d865596d83b160dc143f2543f839e4d05b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/texthtml/oauth2-provider/zipball/8c4307d865596d83b160dc143f2543f839e4d05b",
+                "reference": "8c4307d865596d83b160dc143f2543f839e4d05b",
+                "shasum": ""
+            },
+            "require": {
+                "bshaffer/oauth2-server-httpfoundation-bridge": "~1.0",
+                "bshaffer/oauth2-server-php": "~1.5",
+                "symfony/security": "~2.5"
+            },
+            "require-dev": {
+                "php-vfs/php-vfs": "~1.2",
+                "phpspec/phpspec": "~2.0",
+                "pimple/pimple": "~3.0",
+                "silex/silex": "~2.0@dev"
+            },
+            "suggest": {
+                "silex/silex": "Provide a light framework to build PHP applications"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TH\\OAuth2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathieu Rochette",
+                    "email": "mathieu@rochette.cc"
+                }
+            ],
+            "description": "OAuth2 provider for the Symfony Security component",
+            "time": "2014-12-21 22:50:43"
         }
     ],
     "packages-dev": [
@@ -2579,16 +2794,16 @@
         },
         {
             "name": "texthtml/whoops-silex",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/texthtml/whoops-silex.git",
-                "reference": "b74edb8fca556ab7404c0b92adbbef1b350db23d"
+                "reference": "ba3460c477ae2556aa332d8b9bd66c315816901b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/texthtml/whoops-silex/zipball/b74edb8fca556ab7404c0b92adbbef1b350db23d",
-                "reference": "b74edb8fca556ab7404c0b92adbbef1b350db23d",
+                "url": "https://api.github.com/repos/texthtml/whoops-silex/zipball/ba3460c477ae2556aa332d8b9bd66c315816901b",
+                "reference": "ba3460c477ae2556aa332d8b9bd66c315816901b",
                 "shasum": ""
             },
             "require": {
@@ -2619,7 +2834,7 @@
                 "silex",
                 "whoops"
             ],
-            "time": "2014-11-07 12:13:57"
+            "time": "2014-11-11 23:17:59"
         }
     ],
     "aliases": [],
@@ -2628,6 +2843,7 @@
         "silex/silex": 20
     },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.4.0"
     },

--- a/config/config_dev.yml
+++ b/config/config_dev.yml
@@ -2,3 +2,9 @@ imports:
     - config.yml
 imports_after_if_exists:
     - config_my.yml
+gitory:
+    api:
+        clients:
+            NICE_DEV_CLIENT:
+                name: Nice Dev Client
+                redirect_uri: http://localhost:4000/oauth2_callback

--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -1,2 +1,8 @@
 imports:
     - config.yml
+gitory:
+    api:
+        clients:
+            NICE_TEST_CLIENT:
+                name: Nice Test Client
+                redirect_uri: http://nice.test.client/oauth2_callback

--- a/features/bootstrap/ApiContext.php
+++ b/features/bootstrap/ApiContext.php
@@ -1,10 +1,12 @@
 <?php
 
+use Gitory\Gitory\Application;
 use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Client;
+use GuzzleHttp\Post\PostBody;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -14,6 +16,12 @@ use Symfony\Component\Process\PhpExecutableFinder;
  */
 class ApiContext implements SnippetAcceptingContext
 {
+    /**
+     * Gitory application
+     * @var Gitory\Gitory\Application
+     */
+    private $app;
+
     /**
      * API base url
      * @var string
@@ -33,6 +41,11 @@ class ApiContext implements SnippetAcceptingContext
     private $response;
 
     /**
+     * OAuth2 Access Token
+     */
+    private static $OAuth2AccessToken;
+
+    /**
      * Initializes context.
      *
      * Every scenario gets its own context object.
@@ -40,20 +53,55 @@ class ApiContext implements SnippetAcceptingContext
      */
     public function __construct()
     {
+        $this->app = new Application('test');
+
         $this->baseUrl = 'http://'.self::ADDRESS;
     }
 
     /**
-     * Make an API REST request
-     *
-     * @When I make a :method request to :url
+     * @BeforeScenario
      */
-    public function iMakeARequestTo($method, $url, PyStringNode $body = null)
+    public static function resetOAuth2AccessToken()
     {
-        $client = new Client();
-        $client->setDefaultOption('exceptions', false);
-        $this->response = $client->$method($this->baseUrl.$url, ['body' => (string)$body]);
+        self::$OAuth2AccessToken = null;
     }
+
+    /**
+     * @When :user make a :method request to :url
+     */
+    public function makeARequestTo($user, $method, $url, PyStringNode $body = null)
+    {
+        $clientConfig = [
+            'base_url' => $this->baseUrl,
+            'defaults' => ['allow_redirects' => false],
+        ];
+
+        if (self::$OAuth2AccessToken) {
+            $clientConfig['defaults']['headers'] = ['Authorization' => 'Bearer '.self::$OAuth2AccessToken];
+        }
+
+        $client = new Client($clientConfig);
+        $client->setDefaultOption('exceptions', false);
+
+        $body = (string) $body;
+        if (strtolower($method) === 'form') {
+            $method = 'post';
+            $clientConfig['defaults']['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+            $postBody = new PostBody;
+            preg_match_all('/^([^=]+)=(.*)$/m', $body, $matches, PREG_SET_ORDER);
+            $body = [];
+            foreach ($matches as $match) {
+                list($_, $key, $value) = $match;
+                $body[$key] = $value;
+            }
+        }
+
+        $this->response = $client->$method($url, [
+            'auth' => $user === 'I' ? null : explode(':', $user, 2),
+            'body' => $body
+        ]);
+    }
+
 
     /**
      * Check the response JSON
@@ -61,6 +109,7 @@ class ApiContext implements SnippetAcceptingContext
      */
     public function theResponseShouldBe(PyStringNode $response)
     {
+        var_dump((string) $this->response->getBody());
         $dbResponse = $this->response->json();
         $behatResponseTemplate = json_decode((string)$response, true);
 
@@ -94,6 +143,16 @@ class ApiContext implements SnippetAcceptingContext
     }
 
     /**
+     * @Given :clientId is a valid OAuth2 client id
+     */
+    public function isAValidOauthClientId($clientId)
+    {
+        if ($this->app['oauth2_server.storage.client']->getClientDetails($clientId) === null) {
+            throw new Exception("$clientId is not a valid OAuth2 client id (check your config)");
+        }
+    }
+
+    /**
      * @Then the response header :name should be :value
      */
     public function theResponseHeaderShouldBe($name, $value)
@@ -101,6 +160,65 @@ class ApiContext implements SnippetAcceptingContext
         if($this->response->getHeader($name) !== $value) {
             throw new Exception(
                 'Response `'.$name.'` header : '.$this->response->getHeader($name).' does not match '.$value
+            );
+        }
+    }
+
+    /**
+     * @Then the response header :name should match :pattern
+     */
+    public function theResponseHeaderShouldMatch($name, $pattern)
+    {
+
+        if(preg_match("/$pattern/", $this->response->getHeader($name)) !== 1) {
+            throw new Exception(
+                'Response `'.$name.'` header : '.$this->response->getHeader($name).' does not match '.$pattern
+            );
+        }
+    }
+
+    /**
+     * @Given :user got an OAuth2 Access Token: :token
+     */
+    public function gotAnOauthAccessToken($user, $token)
+    {
+        $accessTokenManager = $this->app['oauth2_server.access_token.manager'];
+        $accessTokenManager->setAccessToken($token, 'unknown', $user, strtotime('+1 hour'));
+        static::$OAuth2AccessToken = $token;
+    }
+
+    /**
+     * @Given requests are made on behalf of :user
+     */
+    public function requestsAreMadeOnBehalfOf($user)
+    {
+        return $this->gotAnOauthAccessToken($user, 'YOUR_TOKEN');
+    }
+
+    /**
+     * @Then the response should not contain :text
+     */
+    public function theResponseShouldNotContain($text)
+    {
+        $responseBody = (string)$this->response->getBody();
+
+        if (strpos($responseBody, $text) !== false) {
+            throw new Exception(
+                'Text `'.$text.'` should not have been found in response'
+            );
+        }
+    }
+
+    /**
+     * @Then the response should contain :text
+     */
+    public function theResponseShouldContain($text)
+    {
+        $responseBody = (string)$this->response->getBody();
+
+        if (strpos($responseBody, $text) === false) {
+            throw new Exception(
+                'Text `'.$text.'` was not found in response'
             );
         }
     }

--- a/features/cross-origin-api.feature
+++ b/features/cross-origin-api.feature
@@ -5,7 +5,6 @@ Feature: Cross Origin API
 
     Scenario: List repositories
          When I make a "options" request to "/repositories"
-         Then the response status code should be 200
-          And the response header "Access-Control-Allow-Origin" should be "*"
+         Then the response header "Access-Control-Allow-Origin" should be "*"
           And the response header "Access-Control-Allow-Methods" should be "GET, DELETE, POST, PUT"
-          And the response header "Access-Control-Allow-Headers" should be "Content-Type"
+          And the response header "Access-Control-Allow-Headers" should be "Authorization, Content-Type"

--- a/features/oauth2.feature
+++ b/features/oauth2.feature
@@ -1,0 +1,68 @@
+@wip
+Feature: OAuth2 authentification
+    In order to access the API
+    As an api client
+    I need be able to act on behalf of the user
+
+    Scenario: Anonymous request to protected resource
+         When I make a "get" request to "/repositories"
+         Then the response status code should be 401
+          And the response header "WWW-Authenticate" should be 'Bearer realm="Gitory"'
+
+    Scenario: Authenticated request to protected resource
+        Given "The doctor" got an OAuth2 Access Token: "SONIC_SCREWDRIVER"
+         When I make a "get" request to "/repositories"
+         Then the response status code should be 200
+
+    Scenario: The authorize endpoint is protected
+         When I make a "get" request to "/auth/authorize?response_type=token"
+         Then the response status code should be 401
+
+    Scenario: An Authorize request without a client_id should fail
+         When "admin:foo" make a "get" request to "/auth/authorize?response_type=token"
+         Then the response status code should be 400
+          And the response should contain "invalid_client"
+          And the response should contain "No client id supplied"
+          And the response should not contain "You have been sent here by"
+
+    Scenario: An Authorize request without a valid client_id should fail
+        Given "NICE_TEST_CLIENT" is a valid OAuth2 client id
+         When "admin:foo" make a "get" request to "/auth/authorize?client_id=EVIL_CLIENT&response_type=token"
+         Then the response status code should be 400
+          And the response should contain "invalid_client"
+          And the response should contain "The client id supplied is invalid"
+          And the response should not contain "You have been sent here by"
+
+    Scenario: An Authorize request without a response_type should fail
+         When "admin:foo" make a "get" request to "/auth/authorize?client_id=NICE_TEST_CLIENT"
+         Then the response status code should be 302
+          And the response header "Location" should be "http://nice.test.client/oauth2_callback?error=invalid_request&error_description=Invalid+or+missing+response+type"
+
+    Scenario: An Authorize request without a valid response_type should fail
+         When "admin:foo" make a "get" request to "/auth/authorize?client_id=NICE_TEST_CLIENT&response_type=invalid_response_type"
+         Then the response status code should be 302
+          And the response header "Location" should be "http://nice.test.client/oauth2_callback?error=invalid_request&error_description=Invalid+or+missing+response+type"
+
+    Scenario: A valid Authorize request should asks the user whether he wants to authorize the app
+        Given "NICE_TEST_CLIENT" is a valid OAuth2 client id
+         When "admin:foo" make a "get" request to "/auth/authorize?client_id=NICE_TEST_CLIENT&response_type=token"
+         Then the response status code should be 200
+          And the response should contain "You have been sent here by <strong>NICE_TEST_CLIENT</strong>"
+
+    Scenario: A user can cancel an authorization request
+        Given "NICE_TEST_CLIENT" is a valid OAuth2 client id
+         When "admin:foo" make a "form" request to "/auth/authorize?client_id=NICE_TEST_CLIENT&response_type=token"
+            """
+            authorize=0
+            """
+         Then the response status code should be 302
+          And the response header "Location" should be "http://nice.test.client/oauth2_callback?error=access_denied&error_description=The+user+denied+access+to+your+application"
+
+    Scenario: A user can accept an authorization request
+        Given "NICE_TEST_CLIENT" is a valid OAuth2 client id
+         When "admin:foo" make a "form" request to "/auth/authorize?client_id=NICE_TEST_CLIENT&response_type=token"
+            """
+            authorize=1
+            """
+         Then the response status code should be 302
+          And the response header "Location" should match "nice.test.client\/oauth2_callback#access_token=[0-9a-f]+&expires_in=3600&token_type=Bearer$"

--- a/features/repositories-api.feature
+++ b/features/repositories-api.feature
@@ -5,7 +5,8 @@ Feature: Repositories basic API
 
     Background:
         Given there is a repository named "gallifrey"
-          And there is a repository named "the-doctor"
+          And there is a repository named "the-tardis"
+          And requests are made on behalf of "The Doctor"
 
     Scenario: List repositories
          When I make a "get" request to "/repositories"
@@ -13,7 +14,7 @@ Feature: Repositories basic API
             """
             [
                 {"identifier": "gallifrey"},
-                {"identifier": "the-doctor"}
+                {"identifier": "the-tardis"}
             ]
             """
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "version": "0.1.0",
   "description": "Gitory",
   "main": "js/index.js",
-  "dependencies": {
-    "angular-restmod": "git://github.com/mpeck/angular-restmod#add-name-and-version-to-packagejson"
-  },
   "devDependencies": {
     "angular": "~1.3.0",
     "angular-mocks": "~1.3.0",
+    "angular-restmod": "git://github.com/platanus/angular-restmod",
     "browserify": "^5.10.1",
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",

--- a/spec/Gitory/Gitory/Managers/Doctrine/DoctrineOAuth2ServerAccessTokenManagerSpec.php
+++ b/spec/Gitory/Gitory/Managers/Doctrine/DoctrineOAuth2ServerAccessTokenManagerSpec.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace spec\Gitory\Gitory\Managers\Doctrine;
+
+use Gitory\Gitory\Managers\Doctrine\DoctrineOAuth2ServerAccessTokenManager;
+use Gitory\Gitory\Entities\OAuth2Server\AccessToken;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectRepository;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use DateTime;
+
+class DoctrineOAuth2ServerAccessTokenManagerSpec extends ObjectBehavior
+{
+    public function let(
+        ManagerRegistry $registry,
+        ObjectManager $om,
+        ObjectRepository $accessTokenRepository
+    )
+    {
+        $this->beConstructedWith($registry);
+        $registry->getManagerForClass(DoctrineOAuth2ServerAccessTokenManager::ENTITY_CLASS)->willReturn($om);
+        $om->getRepository(DoctrineOAuth2ServerAccessTokenManager::ENTITY_CLASS)->willReturn($accessTokenRepository);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('Gitory\Gitory\Managers\Doctrine\DoctrineOAuth2ServerAccessTokenManager');
+        $this->shouldImplement('OAuth2\Storage\AccessTokenInterface');
+    }
+
+    public function it_gets_null_for_missong_token(ObjectRepository $accessTokenRepository)
+    {
+        $token = 'a token';
+        $accessTokenRepository->find($token)->willReturn(null);
+        $this->getAccessToken($token)->shouldReturn(null);;
+    }
+
+    public function it_gets_access_token(
+        ObjectRepository $accessTokenRepository,
+        AccessToken $accessToken,
+        DateTime $expires
+    ) {
+        $token = 'a token';
+        $accessTokenArray = [
+            'expires' => 42,
+            'client_id' => 43,
+            'user_id' => 44,
+            'scope' => 'some scopes',
+        ];
+        $accessToken->clientId()->willReturn($accessTokenArray['client_id']);
+        $accessToken->userId()->willReturn($accessTokenArray['user_id']);
+        $accessToken->scopes()->willReturn(explode(' ', $accessTokenArray['scope']));
+        $expires->getTimestamp()->willReturn($accessTokenArray['expires']);
+        $accessToken->expires()->willReturn($expires);
+        $accessTokenRepository->find($token)->willReturn($accessToken);
+        $this->getAccessToken($token)->shouldReturn($accessTokenArray);
+    }
+
+    public function it_sets_access_token_without_scopes(
+        ObjectManager $om
+    ) {
+        $accessTokenArray = [
+            'expires' => 42,
+            'client_id' => 43,
+            'user_id' => 44,
+        ];
+        $om->flush()->shouldBeCalled();
+        $om->persist(Argument::that(function (AccessToken $accessToken) use ($accessTokenArray) {
+            if ($accessToken->clientId() !== $accessTokenArray['client_id']) {
+                return false;
+            }
+            if ($accessToken->userId() !== $accessTokenArray['user_id']) {
+                return false;
+            }
+            if ($accessToken->expires()->getTimestamp() !== $accessTokenArray['expires']) {
+                return false;
+            }
+            $scopes = $accessToken->scopes();
+            if (!is_array($scopes) || !empty($scopes)) {
+                return false;
+            }
+            return true;
+        }))->shouldBeCalled();
+        $this->setAccessToken(
+            'a token',
+            $accessTokenArray['client_id'],
+            $accessTokenArray['user_id'],
+            $accessTokenArray['expires']
+        );
+    }
+
+    public function it_sets_access_token_with_scopes(
+        ObjectManager $om
+    ) {
+        $accessTokenArray = [
+            'expires' => 42,
+            'client_id' => 43,
+            'user_id' => 44,
+            'scope' => 'some scopes',
+        ];
+        $om->flush()->shouldBeCalled();
+        $om->persist(Argument::that(function (AccessToken $accessToken) use ($accessTokenArray) {
+            $scopes = $accessToken->scopes();
+            if (!is_array($scopes)) {
+                return false;
+            }
+            if (count($scopes) !== 2) {
+                return false;
+            }
+            return implode(' ', $scopes) === $accessTokenArray['scope'];
+        }))->shouldBeCalled();
+        $this->setAccessToken(
+            'a token',
+            $accessTokenArray['client_id'],
+            $accessTokenArray['user_id'],
+            $accessTokenArray['expires'],
+            $accessTokenArray['scope']
+        );
+    }
+}

--- a/src/Entities/OAuth2Server/AccessToken.php
+++ b/src/Entities/OAuth2Server/AccessToken.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Gitory\Gitory\Entities\OAuth2Server;
+
+use DateTime;
+
+/** @Entity */
+class AccessToken
+{
+    /**
+     * @Id @Column
+     */
+    private $oauthToken;
+
+    /**
+     * @Column(type="datetime")
+     */
+    private $expires;
+
+    /**
+     * @Column
+     */
+    private $clientId;
+
+    /**
+     * @Column
+     */
+    private $userId;
+
+    /**
+     * @Column(type="array")
+     */
+    private $scopes;
+
+    public function __construct($oauthToken, $clientId, $userId, DateTime $expires, Array $scopes)
+    {
+        $this->oauthToken = $oauthToken;
+        $this->clientId = $clientId;
+        $this->userId = $userId;
+        $this->expires = $expires;
+        $this->scopes = $scopes;
+    }
+
+    public function expires()
+    {
+        return $this->expires;
+    }
+
+    public function clientId()
+    {
+        return $this->clientId;
+    }
+
+    public function userId()
+    {
+        return $this->userId;
+    }
+
+    public function scopes()
+    {
+        return $this->scopes;
+    }
+}

--- a/src/Managers/Doctrine/DoctrineOAuth2ServerAccessTokenManager.php
+++ b/src/Managers/Doctrine/DoctrineOAuth2ServerAccessTokenManager.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Gitory\Gitory\Managers\Doctrine;
+
+use OAuth2\Storage\AccessTokenInterface;
+use Gitory\Gitory\Entities\OAuth2Server\AccessToken;
+use DateTime;
+
+class DoctrineOAuth2ServerAccessTokenManager implements AccessTokenInterface
+{
+    use DoctrineRepository;
+
+    const ENTITY_CLASS = 'Gitory\Gitory\Entities\OAuth2Server\AccessToken';
+
+    /**
+     * @inherit
+     */
+    public function getAccessToken($oauth_token)
+    {
+        $accessToken = $this->getRepository()->find($oauth_token);
+        if ($accessToken === null) {
+            return null;
+        }
+        return [
+            'expires' => $accessToken->expires()->getTimestamp(),
+            'client_id' => $accessToken->clientId(),
+            'user_id' => $accessToken->userId(),
+            'scope' => implode(' ', $accessToken->scopes()),
+        ];
+    }
+
+    /**
+     * Store the supplied access token values to storage.
+     *
+     * We need to store access token data as we create and verify tokens.
+     *
+     * @param $oauth_token    oauth_token to be stored.
+     * @param $client_id      client identifier to be stored.
+     * @param $user_id        user identifier to be stored.
+     * @param int    $expires expiration to be stored as a Unix timestamp.
+     * @param string $scope   OPTIONAL Scopes to be stored in space-separated string.
+     *
+     * @ingroup oauth2_section_4
+     */
+    public function setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope = null)
+    {
+        $datetime = new DateTime;
+        $datetime->setTimestamp($expires);
+        $accessToken = new AccessToken(
+            $oauth_token,
+            $client_id,
+            $user_id,
+            $datetime,
+            empty($scope) ? [] : explode(' ', $scope)
+        );
+        $manager = $this->getManager();
+        $manager->persist($accessToken);
+        $manager->flush();
+    }
+}

--- a/src/Managers/Doctrine/DoctrineRepository.php
+++ b/src/Managers/Doctrine/DoctrineRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gitory\Gitory\Managers\Doctrine;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+
+trait DoctrineRepository
+{
+    private $registry;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        return $this->registry = $registry;
+    }
+
+    /**
+     * Get entity manager
+     * @return \Doctrine\Common\Persistence\ObjectManager|null entity manager
+     */
+    private function getManager()
+    {
+        return $this->registry->getManagerForClass(static::ENTITY_CLASS);
+    }
+
+    /**
+     * Get doctrine repository
+     * @return Doctrine\Common\Persistence\ObjectRepository
+     */
+    private function getRepository()
+    {
+        return $this->getManager()->getRepository(static::ENTITY_CLASS);
+    }
+}

--- a/src/Managers/Doctrine/DoctrineRepositoryManager.php
+++ b/src/Managers/Doctrine/DoctrineRepositoryManager.php
@@ -6,16 +6,11 @@ use Gitory\Gitory\Managers\RepositoryManager;
 use Gitory\Gitory\Entities\Repository;
 use Gitory\Gitory\Exceptions\ExistingRepositoryIdentifierException;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectRepository;
 use Psr\Log\LoggerInterface;
 
 class DoctrineRepositoryManager implements RepositoryManager
 {
-    /**
-     * Doctrine registry
-     * @var \Doctrine\Common\Persistence\ManagerRegistry
-     */
-    private $registry;
+    use DoctrineRepository;
 
     /**
      * @var LoggerInterface
@@ -73,23 +68,5 @@ class DoctrineRepositoryManager implements RepositoryManager
         $this->logger->notice('Repository "{identifier}" has been created in database', ['identifier' => $identifier]);
 
         return $repository;
-    }
-
-    /**
-     * Get entity manager
-     * @return \Doctrine\Common\Persistence\ObjectManager|null entity manager
-     */
-    private function getManager()
-    {
-        return $this->registry->getManagerForClass(DoctrineRepositoryManager::ENTITY_CLASS);
-    }
-
-    /**
-     * Get doctrine repository
-     * @return Doctrine\Common\Persistence\ObjectRepository
-     */
-    private function getRepository()
-    {
-        return $this->getManager()->getRepository(self::ENTITY_CLASS);
     }
 }

--- a/views/authorize.php
+++ b/views/authorize.php
@@ -1,0 +1,24 @@
+<h1>Gitory</h1>
+
+<p>
+    <?php if ($user !== null): ?>
+    Hi <strong><?= $user->getUsername() ?></strong>.
+    <?php endif; ?>
+    You have been sent here by <strong><?= $clientId ?></strong>.
+</p>
+
+<p>
+    Click the button below to complete the authorize request and grant an <code>
+    <?= $responseType === 'code' ? 'Authoriation Code' : 'Access Token' ?></code> to <?= $clientId ?>.
+</p>
+
+<div>
+    <form method="post" action="<?= htmlspecialchars($formUrl) ?>">
+        <input type="submit" value="Yes, I Authorize This Request" />
+        <input type="hidden" name="authorize" value="1" />
+    </form>
+    <form method="post" action="<?= htmlspecialchars($formUrl) ?>">
+        <input type="submit" value="Cancel" />
+        <input type="hidden" name="authorize" value="0" />
+    </form>
+</div>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -8,11 +8,17 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no">
 
 		<link rel="stylesheet" type="text/css" href="/gitory.css"/>
-
+		<base href="/">
 		<script src="/gitory.js"></script>
 	</head>
 	<body>
 		<h1>Gitory</h1>
+
+		<gitory:o-auth2-login-button
+			client-id="NICE_DEV_CLIENT"
+			response-type="token"
+			callback-path="/oauth2_callback"
+		></gitory:o-auth2-login-button>
 
 		<gitory:repositories collection-name="repositories"></gitory:repositories>
 

--- a/web/src/js/directives.js
+++ b/web/src/js/directives.js
@@ -6,5 +6,6 @@
 	require('./directives/repositories')(directives);
 	require('./directives/repositories/list')(directives);
 	require('./directives/repositories/form')(directives);
+	require('./directives/oauth2/login-button')(directives);
 	module.exports = directives;
 }) ();

--- a/web/src/js/directives/oauth2/login-button.js
+++ b/web/src/js/directives/oauth2/login-button.js
@@ -1,0 +1,76 @@
+module.exports = function(module) {
+	'use strict';
+
+	var OAuth2LoginButtonCtrl = function(Authorization, $window, $interval, $q, $location) {
+		var clientId = encodeURIComponent(this.clientId);
+		var responseType = encodeURIComponent(this.responseType);
+		var url = 'http://localhost:4001/auth/authorize?client_id=' + clientId + '&response_type=' + responseType;
+		var oauth2AuthorizationResponseKey = 'oauth2-authorization-response';
+
+		var readOAuth2AuthorizationResponse = function() {
+			var oauth2AuthorizationResponse = $window.localStorage.getItem(oauth2AuthorizationResponseKey);
+
+			if (oauth2AuthorizationResponse !== null) {
+				$window.localStorage.removeItem(oauth2AuthorizationResponseKey);
+				return JSON.parse(oauth2AuthorizationResponse);
+			}
+		};
+
+		readOAuth2AuthorizationResponse();
+
+		if ($location.path() === this.callbackPath) {
+			var oauth2AuthorizationResponse = $location.search();
+			var accessTokenMatch = /access_token=([a-f0-9]+)[^a-f0_9]/.exec($location.hash());
+			if (accessTokenMatch !== null) {
+				oauth2AuthorizationResponse = {
+					token: accessTokenMatch[1]
+				};
+			}
+			$window.localStorage.setItem(
+				oauth2AuthorizationResponseKey,
+				JSON.stringify(oauth2AuthorizationResponse)
+			);
+			$window.close();
+		}
+
+		var waitForAuthorization = function(authorizationWindow) {
+			var authorizationRequest = $q.defer();
+			var interval = $interval(function() {
+				if (authorizationWindow.closed) {
+					$interval.cancel(interval);
+					var oauth2AuthorizationResponse = readOAuth2AuthorizationResponse();
+
+					if (oauth2AuthorizationResponse.token !== undefined) {
+						authorizationRequest.resolve(oauth2AuthorizationResponse.token);
+					} else {
+						authorizationRequest.reject(oauth2AuthorizationResponse);
+					}
+				}
+			}, 100);
+			return authorizationRequest.promise;
+		};
+
+		this.required = function() {
+			return Authorization.required();
+		};
+		this.login = function() {
+			return waitForAuthorization($window.open(url)).then(Authorization.authorize);
+		};
+	};
+	OAuth2LoginButtonCtrl.$inject = ['Authorization', '$window', '$interval', '$q', '$location'];
+
+	return module.directive('gitoryOAuth2LoginButton', function() {
+		return {
+			scope: {
+				'clientId': '@',
+				'responseType': '@',
+				'callbackPath': '@'
+			},
+			templateUrl: 'directives/oauth2/login-button.html',
+			controller: 'OAuth2LoginButtonCtrl',
+			controllerAs: 'ctrl',
+			bindToController: true
+		};
+	})
+	.controller('OAuth2LoginButtonCtrl', OAuth2LoginButtonCtrl);
+};

--- a/web/src/js/gitory.js
+++ b/web/src/js/gitory.js
@@ -8,6 +8,8 @@
 
 	require('./directives');
 	require('./services').config(process.env.API_BASE_URI.replace(/\/$/, ''));
-	angular.module('gitory', ['gitory.directives']);
+	angular.module('gitory', ['gitory.directives']).config(['$locationProvider', function($locationProvider) {
+		$locationProvider.html5Mode(true);
+	}]);
 	require('../../tmp/templates.js');
 }) ();

--- a/web/src/js/services.js
+++ b/web/src/js/services.js
@@ -2,7 +2,12 @@
 	'use strict';
 
 	var angular = require('./angular');
-	var repositoriesFactory = require('./services/repositories');
+	var servicesDefinitions = [
+		require('./services/authorization'),
+		require('./services/authorization/interceptor'),
+		// require('./services/session'),
+		require('./services/repositories')
+	];
 	require('./restmod');
 
 	module.exports = {
@@ -18,7 +23,17 @@
 				});
 			}]);
 
-			services.factory('Repositories', repositoriesFactory);
+			for (var i = 0; i < servicesDefinitions.length; i++) {
+				var serviceDefinition = servicesDefinitions[i];
+
+				if (serviceDefinition.config !== undefined) {
+					services.config(serviceDefinition.config);
+				}
+
+				if (serviceDefinition.provider !== undefined) {
+					services.factory(serviceDefinition.name, serviceDefinition.provider);
+				}
+			}
 		}
 	};
 }) ();

--- a/web/src/js/services/authorization.js
+++ b/web/src/js/services/authorization.js
@@ -1,0 +1,59 @@
+(function() {
+	'use strict';
+
+	var authorizationProvider = function($q, $window) {
+		var requested = false;
+		var authorize = $q.defer();
+		var logout = $q.defer();
+		var authorizationTokenStorageKey = 'authorization-token';
+		var token = null;
+
+		var Authorization = {
+			request: function() {
+				requested = true;
+				return authorize.promise;
+			},
+			requested: function() {
+				return requested;
+			},
+			authorize: function(newToken) {
+				token = newToken;
+				if (token === null) {
+					$window.localStorage.removeItem(authorizationTokenStorageKey);
+					logout.resolve();
+					authorize = $q.defer();
+				} else {
+					$window.localStorage.setItem(authorizationTokenStorageKey, token);
+					logout = $q.defer();
+					authorize.resolve();
+				}
+			},
+			token: function() {
+				return token;
+			},
+			onlogout: function() {
+				return logout.promise;
+			},
+			logout: function() {
+				this.authorize(null);
+			}
+		};
+
+		Authorization.authorize($window.localStorage.getItem(authorizationTokenStorageKey));
+
+		return Authorization;
+	};
+
+	var authorizationConfig = function($httpProvider) {
+		$httpProvider.interceptors.push('authorizationInterceptor');
+	};
+
+	authorizationConfig.$inject = ['$httpProvider'];
+	authorizationProvider.$inject = ['$q', '$window'];
+
+	module.exports = {
+		name: 'Authorization',
+		provider: authorizationProvider,
+		config: authorizationConfig
+	};
+}) ();

--- a/web/src/js/services/authorization/interceptor.js
+++ b/web/src/js/services/authorization/interceptor.js
@@ -1,0 +1,31 @@
+(function() {
+	'use strict';
+
+	var authorizationInterceptor = function($q, Authorization, $injector) {
+		return {
+			request: function(request) {
+				var token = Authorization.token();
+				if (token !== null) {
+					request.headers.Authorization = 'Bearer ' + token;
+				}
+				return request;
+			},
+			responseError: function(response) {
+				if (response.status === 401) {
+					return Authorization.request().then(function() {
+						return $injector.get('$http')(response.config);
+					});
+				}
+
+				return $q.reject(response);
+			}
+		};
+	};
+
+	authorizationInterceptor.$inject = ['$q', 'Authorization', '$injector'];
+
+	module.exports = {
+		name: 'authorizationInterceptor',
+		provider: authorizationInterceptor
+	};
+}) ();

--- a/web/src/js/services/repositories.js
+++ b/web/src/js/services/repositories.js
@@ -1,7 +1,14 @@
 (function() {
 	'use strict';
 
-	module.exports = ['restmod', function(restmod) {
+	var repositories = function(restmod) {
 		return restmod.model('/repositories');
-	}];
+	};
+
+	repositories.$inject = ['restmod'];
+
+	module.exports = {
+		name: 'Repositories',
+		provider: repositories
+	};
 }) ();

--- a/web/src/views/directives/oauth2/login-button.html
+++ b/web/src/views/directives/oauth2/login-button.html
@@ -1,0 +1,1 @@
+<button ng-click="ctrl.login()">login</button>


### PR DESCRIPTION
* [x] Add OAuth2 Authorize entry point (with grant types: Implicit Authorization Code ~~, Client Credentials And Refresh Token~~)
* ~~[ ] Add OAuth2 Token entry point~~
* [x] Add OAuth2 security to API entry points
* ~~[ ] Add OAuth2 scope check in UseCases\* classes~~
* [x] Add Doctrine OAuth2 Storage
* ~~[ ] Setup in-memory Client Credentials for the webapp~~
* [x] Setup in-memory User Credentials
* [x] Add an Authorize action to the webapp
* [x] Authenticate webapp call with its Client Credentials when logout and with User Credentials when logged in

Use in-memory users and clients list, don't support scopes and grant types other than Implicit for now